### PR TITLE
[Feat] Uses webui ROCK instead of upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ juju integrate mongodb-k8s sdcore-webui
 
 ## Image
 
-- **webui**: `omecproject/5gc-webui:master-1121545`
+- **webui**: `ghcr.io/canonical/sdcore-webui:1.3`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   webui-image:
     type: oci-image
     description: OCI image for 5G webui
-    upstream-source: omecproject/5gc-webui:master-1121545
+    upstream-source: ghcr.io/canonical/sdcore-webui:1.3
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -142,7 +142,7 @@ class WebuiOperatorCharm(CharmBase):
                     "webui": {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"./webconsole/webconsole -webuicfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",  # noqa: E501
+                        "command": f"/bin/webconsole --webuicfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",  # noqa: E501
                         "environment": self._environment_variables,
                     },
                 },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -112,7 +112,7 @@ class TestCharm(unittest.TestCase):
             "services": {
                 "webui": {
                     "override": "replace",
-                    "command": "./webconsole/webconsole -webuicfg /etc/webui/webuicfg.conf",
+                    "command": "/bin/webconsole --webuicfg /etc/webui/webuicfg.conf",
                     "startup": "enabled",
                     "environment": {
                         "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",


### PR DESCRIPTION
# Description

Uses webui ROCK instead of upstream image. Depends on:
- https://github.com/canonical/sdcore-webui-rock/pull/1

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library