### PR TITLE
fix: go into blocked status when database relation is removed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -91,6 +91,7 @@ class WebuiOperatorCharm(CharmBase):
         self._sdcore_management = SdcoreManagementProvides(self, SDCORE_MANAGEMENT_RELATION_NAME)
         self.framework.observe(self.on.webui_pebble_ready, self._on_webui_pebble_ready)
         self.framework.observe(self.on.database_relation_joined, self._on_webui_pebble_ready)
+        self.framework.observe(self.on.database_relation_broken, self._on_database_relation_broken)
         self.framework.observe(self._database.on.database_created, self._on_database_created)
         self.framework.observe(self._database.on.endpoints_changed, self._on_database_created)
         self.framework.observe(
@@ -164,6 +165,14 @@ class WebuiOperatorCharm(CharmBase):
         self._sdcore_management.set_management_url(
             management_url=self._get_webui_endpoint_url(),
         )
+
+    def _on_database_relation_broken(self, event: EventBase) -> None:
+        """Event handler for database relation broken.
+
+        Args:
+            event: Juju event
+        """
+        self.unit.status = BlockedStatus("Waiting for database relation")
 
     def _write_config_file(self, content: str) -> None:
         """Writes configuration file based on provided content.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -73,6 +73,27 @@ async def test_relate_and_wait_for_active_status(
     )
 
 
+@pytest.mark.skip(
+    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
+)
+@pytest.mark.abort_on_fail
+async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(DATABASE_APP_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
+
+
+@pytest.mark.skip(
+    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
+)
+@pytest.mark.abort_on_fail
+async def test_restore_database_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await _deploy_database(ops_test)
+    await ops_test.model.integrate(relation1=APP_NAME, relation2=DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+
+
 @pytest.mark.abort_on_fail
 async def test_when_scale_app_beyond_1_then_only_one_unit_is_active(
     ops_test: OpsTest, build_and_deploy


### PR DESCRIPTION
# Description

This PR aims to fix #19. When database relation is removed, move into Blocked status.
As agreed, new integration tests are not executed until canonical/mongodb-k8s-operator#218 will be fixed.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library