### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
     with:
-      charm-file-name: "sdcore-webui_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-webui-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,5 +39,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-webui_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-webui-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# SD-Core Webui Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-webui/badge.svg)](https://charmhub.io/sdcore-webui)
+# SD-Core Webui Operator for K8s
+[![CharmHub Badge](https://charmhub.io/sdcore-webui-k8s/badge.svg)](https://charmhub.io/sdcore-webui-k8s)
 
-A Charmed Operator for SD-Core's Webui component, a configuration service in SD-Core. 
+A Charmed Operator for SD-Core's Webui component for K8s, a configuration service in SD-Core. 
 
 ## Usage
 
 ```bash
 juju deploy mongodb-k8s --trust --channel=5/edge
-juju deploy sdcore-webui --channel=edge
-juju integrate mongodb-k8s sdcore-webui
+juju deploy sdcore-webui-k8s --channel=edge
+juju integrate mongodb-k8s sdcore-webui-k8s
 ```
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core Webui Operator for K8s
+# SD-Core Webui Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-webui-k8s/badge.svg)](https://charmhub.io/sdcore-webui-k8s)
 
 A Charmed Operator for SD-Core's Webui component for K8s, a configuration service in SD-Core. 

--- a/lib/charms/sdcore_webui_k8s/v0/sdcore_management.py
+++ b/lib/charms/sdcore_webui_k8s/v0/sdcore_management.py
@@ -14,7 +14,7 @@ to be able to provide or consume the information to access the configuration ser
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_webui.v0.sdcore_management
+charmcraft fetch-lib charms.sdcore_webui_k8s.v0.sdcore_management
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -30,7 +30,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_webui.v0.sdcore_management import (
+from charms.sdcore_webui_k8s.v0.sdcore_management import (
     ManagementUrlAvailable,
     SdcoreManagementRequires,
 )
@@ -66,7 +66,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_webui.v0.sdcore_management import (
+from charms.sdcore_webui_k8s.v0.sdcore_management import (
     SdcoreManagementProvides,
 )
 
@@ -105,7 +105,7 @@ from ops.model import Relation
 from pydantic import BaseModel, Field, HttpUrl, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "e879ede87229469981725ef404973ee5"
+LIBID = "46698369ff444f10a4e86984c078ee82"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,12 +1,12 @@
-name: sdcore-webui
+name: sdcore-webui-k8s
 
-display-name: SD-Core 5G WEBUI
+display-name: SD-Core 5G WEBUI K8s
 summary: A Charmed Operator for SD-Core's Webui component.
 description: |
   A Charmed Operator for SD-Core's Webui component, a configuration service in SD-Core.
-website: https://charmhub.io/sdcore-webui
-source: https://github.com/canonical/sdcore-webui-operator
-issues: https://github.com/canonical/sdcore-webui-operator/issues
+website: https://charmhub.io/sdcore-webui-k8s
+source: https://github.com/canonical/sdcore-webui-k8s-operator
+issues: https://github.com/canonical/sdcore-webui-k8s-operator/issues
 
 containers:
   webui:

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the 5G Webui service."""
+"""Charmed operator for the 5G Webui service for K8s."""
 
 import logging
 from ipaddress import IPv4Address

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,7 +13,7 @@ from charms.data_platform_libs.v0.data_interfaces import (  # type: ignore[impor
     DatabaseCreatedEvent,
     DatabaseRequires,
 )
-from charms.sdcore_webui.v0.sdcore_management import (  # type: ignore[import]
+from charms.sdcore_webui_k8s.v0.sdcore_management import (  # type: ignore[import]
     SdcoreManagementProvides,
 )
 from jinja2 import Environment, FileSystemLoader

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/unit/lib/charms/sdcore-webui/v0/test_sdcore_management_provider_interface.py
+++ b/tests/unit/lib/charms/sdcore-webui/v0/test_sdcore_management_provider_interface.py
@@ -9,7 +9,7 @@ import pytest
 from ops import testing
 from ops.charm import CharmBase, RelationJoinedEvent
 
-from lib.charms.sdcore_webui.v0.sdcore_management import SdcoreManagementProvides
+from lib.charms.sdcore_webui_k8s.v0.sdcore_management import SdcoreManagementProvides
 
 METADATA = """
 name: sdcore-management-dummy-provider

--- a/tests/unit/lib/charms/sdcore-webui/v0/test_sdcore_management_requirer_interface.py
+++ b/tests/unit/lib/charms/sdcore-webui/v0/test_sdcore_management_requirer_interface.py
@@ -8,7 +8,7 @@ from unittest.mock import call, patch
 from ops import testing
 from ops.charm import CharmBase
 
-from lib.charms.sdcore_webui.v0.sdcore_management import (
+from lib.charms.sdcore_webui_k8s.v0.sdcore_management import (
     ManagementUrlAvailable,
     SdcoreManagementRequires,
 )
@@ -26,7 +26,7 @@ requires:
 
 logger = logging.getLogger(__name__)
 
-CHARM_LIB_PATH = "lib.charms.sdcore_webui.v0.sdcore_management"
+CHARM_LIB_PATH = "lib.charms.sdcore_webui_k8s.v0.sdcore_management"
 
 
 class DummySdcoreManagementRequires(CharmBase):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -171,7 +171,9 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_webui.v0.sdcore_management.SdcoreManagementProvides.set_management_url")
+    @patch(
+        "charms.sdcore_webui_k8s.v0.sdcore_management.SdcoreManagementProvides.set_management_url"
+    )
     def test_given_webui_url_not_available_when_sdcore_management_relation_joined_then_url_not_set(  # noqa: E501
         self,
         patch_set_management_url,
@@ -185,7 +187,9 @@ class TestCharm(unittest.TestCase):
         patch_set_management_url.assert_not_called()
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_webui.v0.sdcore_management.SdcoreManagementProvides.set_management_url")
+    @patch(
+        "charms.sdcore_webui_k8s.v0.sdcore_management.SdcoreManagementProvides.set_management_url"
+    )
     def test_given_webui_url_available_when_sdcore_management_relation_joined_then_url_is_passed_in_relation(  # noqa: E501
         self,
         patch_set_management_url,


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit).

- Create new sdcore_management library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library